### PR TITLE
Remove dependency on deprecated Python module `pipes`

### DIFF
--- a/gradelib.py
+++ b/gradelib.py
@@ -238,8 +238,7 @@ def make(*target):
     post_make()
 
 def show_command(cmd):
-    from pipes import quote
-    print("\n$", " ".join(map(quote, cmd)))
+    print("\n$", " ".join(map(repr, cmd)))
 
 def maybe_unlink(*paths):
     for path in paths:


### PR DESCRIPTION
The module was removed in Python 3.13, so `gradelib` cannot run on systems with Python 3.13 and up without this change.